### PR TITLE
文章与归档页面添加升降序切换按钮

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -63,9 +63,11 @@ export default defineAppConfig({
         emojiTail: ['📄', '🦌', '🙌', '🐟', '🏖️'],
     },
 
-    indexGenerator: {
+    pagination: {
         perPage: 10,
-        orderBy: <ArticleOrderType>'date',
+        sortOrder: <ArticleOrderType>'date',
+        /** 允许（普通/预览/归档）文章列表正序 */
+        allowAscending: false,
     },
 
     nav: <Nav>[

--- a/app/components/partial/OrderToggle.vue
+++ b/app/components/partial/OrderToggle.vue
@@ -1,46 +1,46 @@
 <script setup lang="ts">
-//排序方向枚举
-enum SortOrder{
+const emit = defineEmits<{
+    direction: []
+}>()
+
+enum SortOrder {
     Ascending = '升序',
     Descending = '降序',
 }
 
 const appConfig = useAppConfig()
-
 const orderMap = appConfig.article.order
 const orderDirection = ref(SortOrder.Descending)
-const orderText = computed(()=>orderDirection.value)
 
 const orderBy = defineModel<keyof typeof orderMap>({
     required: true,
     default: 'date',
 })
-const emit = defineEmits([
-    'direction'
-])
 
-function switchOrder() {
+function toggleOrder() {
     const orderKeys = Object.keys(orderMap) as (keyof typeof orderMap)[]
-    const currentIndex = orderKeys.indexOf(orderBy.value)
-    orderBy.value = orderKeys[(currentIndex + 1) % orderKeys.length]!
+    orderBy.value = orderKeys[(orderKeys.indexOf(orderBy.value) + 1) % orderKeys.length]!
 }
-const switchDirection = ()=>{
-    emit('direction'); //触发排序方向改变事件
-    orderDirection.value = orderDirection.value === SortOrder.Descending ? 
-        SortOrder.Ascending : SortOrder.Descending
+
+function toggleDirection() {
+    orderDirection.value = orderDirection.value === SortOrder.Descending
+        ? SortOrder.Ascending
+        : SortOrder.Descending
+    emit('direction')
 }
 </script>
 
 <template>
     <div class="order-toggle">
-        <Icon :name="orderDirection === SortOrder.Descending ? 
-            'ph:sort-ascending-bold' : 'ph:sort-descending-bold'"
-        /> 
-        <button @click="switchDirection">
-            <span style="margin-right: 1em;">{{ orderText }}</span>
+        <button @click="toggleDirection">
+            <Icon
+                :name="orderDirection === SortOrder.Descending
+                    ? 'ph:sort-ascending-bold' : 'ph:sort-descending-bold'"
+            />
+            <span>{{ orderDirection }}</span>
         </button>
-        
-        <button @click="switchOrder">
+
+        <button @click="toggleOrder">
             <Icon name="ph:clock-bold" />
             <span class="order-text">{{ orderMap[orderBy] }}</span>
         </button>
@@ -57,6 +57,14 @@ const switchDirection = ()=>{
 
         &:hover {
             color: var(--c-primary);
+        }
+
+        & + button {
+            margin-left: 1em;
+        }
+
+        .iconify + span {
+            margin-left: 0.1em;
         }
     }
 }

--- a/app/components/partial/OrderToggle.vue
+++ b/app/components/partial/OrderToggle.vue
@@ -1,48 +1,39 @@
 <script setup lang="ts">
-const emit = defineEmits<{
-    direction: []
-}>()
-
-enum SortOrder {
-    Ascending = '升序',
-    Descending = '降序',
-}
-
+// 当且仅当如此书写时，props.allowAscending 才能正确解析为 undefined
+const props = withDefaults(defineProps<{
+    allowAscending?: boolean | undefined
+}>(), {
+    allowAscending: undefined,
+})
 const appConfig = useAppConfig()
 const orderMap = appConfig.article.order
-const orderDirection = ref(SortOrder.Descending)
+const allowAscending = computed(() => props.allowAscending ?? appConfig.pagination.allowAscending)
 
-const orderBy = defineModel<keyof typeof orderMap>({
-    required: true,
-    default: 'date',
-})
+const sortOrder = defineModel<keyof typeof orderMap>('sortOrder', { default: 'date' })
+const isAscending = defineModel<boolean>('isAscending')
+const orderIcon = computed(() => isAscending.value ? 'ph:sort-descending-bold' : 'ph:sort-ascending-bold')
 
 function toggleOrder() {
     const orderKeys = Object.keys(orderMap) as (keyof typeof orderMap)[]
-    orderBy.value = orderKeys[(orderKeys.indexOf(orderBy.value) + 1) % orderKeys.length]!
+    sortOrder.value = orderKeys[(orderKeys.indexOf(sortOrder.value) + 1) % orderKeys.length] || 'date'
 }
 
 function toggleDirection() {
-    orderDirection.value = orderDirection.value === SortOrder.Descending
-        ? SortOrder.Ascending
-        : SortOrder.Descending
-    emit('direction')
+    if (!allowAscending.value)
+        return
+    isAscending.value = !isAscending.value
 }
 </script>
 
 <template>
     <div class="order-toggle">
-        <button @click="toggleDirection">
-            <Icon
-                :name="orderDirection === SortOrder.Descending
-                    ? 'ph:sort-ascending-bold' : 'ph:sort-descending-bold'"
-            />
-            <span>{{ orderDirection }}</span>
+        <button v-if="allowAscending" aria-label="切换排序方向" @click="toggleDirection">
+            <Icon :name="orderIcon" class="toggle-direction" />
         </button>
 
         <button @click="toggleOrder">
-            <Icon name="ph:clock-bold" />
-            <span class="order-text">{{ orderMap[orderBy] }}</span>
+            <Icon v-if="!allowAscending" :name="orderIcon" />
+            <span class="order-text">{{ orderMap[sortOrder] }}</span>
         </button>
     </div>
 </template>
@@ -66,6 +57,11 @@ function toggleDirection() {
         .iconify + span {
             margin-left: 0.1em;
         }
+    }
+
+    .toggle-direction {
+        display: inline-block;
+        margin-right: -0.7em;
     }
 }
 </style>

--- a/app/pages/archive.vue
+++ b/app/pages/archive.vue
@@ -32,13 +32,13 @@ const listSorted = computed(() => alphabetical(
 ))
 
 const listGrouped = computed(() => {
-    const groupList = Object.entries(
-        group(listSorted.value, article =>new Date(article[orderBy.value]).getFullYear())
-    );
+    const groupList = Object.entries(group(
+        listSorted.value,
+        article => new Date(article[orderBy.value]).getFullYear(),
+    ))
 
-    return orderDirection.value ? groupList.reverse() : groupList;
+    return orderDirection.value ? groupList.reverse() : groupList
 })
-
 
 const yearlyWordCount = computed(() => {
     return listGrouped.value.reduce<Record<string, string>>((acc, [year, yearGroup]) => {
@@ -47,14 +47,15 @@ const yearlyWordCount = computed(() => {
         return acc
     }, {})
 })
-const changeOrderDir = ()=>{
-    orderDirection.value = !orderDirection.value;
+
+function changeOrderDir() {
+    orderDirection.value = !orderDirection.value
 }
 </script>
 
 <template>
     <div class="archive">
-        <ZOrderToggle @direction="changeOrderDir" v-model="orderBy" />
+        <ZOrderToggle v-model="orderBy" @direction="changeOrderDir" />
         <div
             v-for="[year, yearGroup] in listGrouped"
             :key="year"

--- a/app/pages/page.vue
+++ b/app/pages/page.vue
@@ -6,11 +6,11 @@ useSeoMeta({
     description: appConfig.description,
     ogImage: appConfig.author.avatar,
 })
-//分页页数
+// 分页页数
 const perPage = appConfig.indexGenerator.perPage || 10
-//排序字段
+// 排序字段
 const orderBy = ref(appConfig.indexGenerator.orderBy || 'date')
-//排序方向
+// 排序方向
 const orderDirection = ref(true)
 
 const layoutStore = useLayoutStore()
@@ -43,8 +43,9 @@ const listRecommended = computed(() => sort(
     post => post.recommend,
     true,
 ))
-const changeOrderDir = ()=>{
-    orderDirection.value = !orderDirection.value;
+
+function changeOrderDir() {
+    orderDirection.value = !orderDirection.value
 }
 </script>
 
@@ -63,10 +64,10 @@ const changeOrderDir = ()=>{
                     查看预览文章
                 </ZRawLink>
             </div>
-            <ZOrderToggle 
+            <ZOrderToggle
+                v-model="orderBy"
+                class="order-toggle"
                 @direction="changeOrderDir"
-                v-model="orderBy" 
-                class="order-toggle" 
             />
         </div>
         <NuxtPage :list="listPaged" :order-by />

--- a/app/pages/page.vue
+++ b/app/pages/page.vue
@@ -6,12 +6,9 @@ useSeoMeta({
     description: appConfig.description,
     ogImage: appConfig.author.avatar,
 })
-// 分页页数
-const perPage = appConfig.indexGenerator.perPage || 10
-// 排序字段
-const orderBy = ref(appConfig.indexGenerator.orderBy || 'date')
-// 排序方向
-const orderDirection = ref(true)
+const perPage = appConfig.pagination.perPage || 10
+const sortOrder = ref(appConfig.pagination.sortOrder || 'date')
+const isAscending = ref<boolean>()
 
 const layoutStore = useLayoutStore()
 layoutStore.setAside(['blog_stats', 'connectivity'])
@@ -27,8 +24,8 @@ const { data: listRaw } = await useAsyncData(
 
 const listSorted = computed(() => alphabetical(
     listRaw.value,
-    item => item[orderBy.value],
-    orderDirection.value ? 'desc' : 'asc',
+    item => item[sortOrder.value],
+    isAscending.value ? 'asc' : 'desc',
 ))
 
 const { page, totalPages, listPaged } = usePagination(listSorted, {
@@ -43,10 +40,6 @@ const listRecommended = computed(() => sort(
     post => post.recommend,
     true,
 ))
-
-function changeOrderDir() {
-    orderDirection.value = !orderDirection.value
-}
 </script>
 
 <template>
@@ -65,12 +58,11 @@ function changeOrderDir() {
                 </ZRawLink>
             </div>
             <ZOrderToggle
-                v-model="orderBy"
-                class="order-toggle"
-                @direction="changeOrderDir"
+                v-model:is-ascending="isAscending"
+                v-model:sort-order="sortOrder"
             />
         </div>
-        <NuxtPage :list="listPaged" :order-by />
+        <NuxtPage :list="listPaged" :sort-order />
         <ZPagination v-model="page" :per-page :total-pages />
     </div>
 </template>

--- a/app/pages/preview.vue
+++ b/app/pages/preview.vue
@@ -6,10 +6,8 @@ useSeoMeta({
     title: '预览',
     description: `${appConfig.title}的文章预览。`,
 })
-const orderBy = useRouteQuery(
-    'order',
-    () => appConfig.indexGenerator.orderBy || 'date',
-)
+const sortOrder = ref(appConfig.pagination.sortOrder || 'date')
+const isAscending = ref<boolean>()
 
 const layoutStore = useLayoutStore()
 layoutStore.setAside(['blog_log'])
@@ -22,11 +20,12 @@ const { data: listRaw } = await useAsyncData(
     { default: () => [] },
 )
 
-const listSorted = computed(() => alphabetical(
-    listRaw.value,
-    item => item[orderBy.value],
-    'desc',
-))
+const listSorted = computed(() =>
+    alphabetical(
+        listRaw.value,
+        item => item[sortOrder.value],
+        isAscending.value ? 'desc' : 'asc',
+    ))
 </script>
 
 <template>
@@ -39,7 +38,10 @@ const listSorted = computed(() => alphabetical(
                     </ZRawLink>预览
                 </h1>
             </div>
-            <ZOrderToggle v-model="orderBy" />
+            <ZOrderToggle
+                v-model:is-ascending="isAscending"
+                v-model:sort-order="sortOrder"
+            />
         </div>
         <p>勇敢的人探索世界。这里是一些还未发布的文章。</p>
 
@@ -49,7 +51,7 @@ const listSorted = computed(() => alphabetical(
                 :key="article._path"
                 v-bind="article"
                 :to="article._path"
-                :use-updated="orderBy === 'updated'"
+                :use-updated="sortOrder === 'updated'"
             />
         </menu>
     </div>


### PR DESCRIPTION
OrderRoggle组件添加emit事件，添加排序方式按钮，用于更改文章列表的排序方向；
page页面添加列表升降序切换功能，按时间切换；
archive页面+，按年份切换