### PR TITLE
feat: ProseA支持禁用自动图标

### DIFF
--- a/app/components/content/ProseA.vue
+++ b/app/components/content/ProseA.vue
@@ -4,7 +4,7 @@ const props = defineProps<{
 	icon?: string
 }>()
 
-const icon = computed(() => props.icon || getDomainIcon(props.href))
+const icon = computed(() => props.icon ?? getDomainIcon(props.href))
 const tip = computed(() => ({
 	content: isExtLink(props.href) ? getDomain(props.href) : safelyDecodeUriComponent(props.href),
 	inlinePositioning: true,

--- a/app/components/content/ProseA.vue
+++ b/app/components/content/ProseA.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 const props = defineProps<{
 	href: string
-	icon?: string
+	icon?: string | boolean
 }>()
 
-const icon = computed(() => props.icon ?? getDomainIcon(props.href))
+const icon = computed(() => typeof props.icon === 'string' ? props.icon : getDomainIcon(props.href))
 const tip = computed(() => ({
 	content: isExtLink(props.href) ? getDomain(props.href) : safelyDecodeUriComponent(props.href),
 	inlinePositioning: true,

--- a/app/components/content/ProseA.vue
+++ b/app/components/content/ProseA.vue
@@ -4,7 +4,11 @@ const props = defineProps<{
 	icon?: string | boolean
 }>()
 
-const icon = computed(() => typeof props.icon === 'string' ? props.icon : getDomainIcon(props.href))
+const icon = computed(() => {
+	if (props.icon === false) return false
+	if (typeof props.icon === 'string') return props.icon
+	return getDomainIcon(props.href)
+})
 const tip = computed(() => ({
 	content: isExtLink(props.href) ? getDomain(props.href) : safelyDecodeUriComponent(props.href),
 	inlinePositioning: true,

--- a/app/components/content/ProseA.vue
+++ b/app/components/content/ProseA.vue
@@ -1,14 +1,10 @@
 <script setup lang="ts">
 const props = defineProps<{
 	href: string
-	icon?: string | boolean
+	icon?: string | false
 }>()
 
-const icon = computed(() => {
-	if (props.icon === false) return false
-	if (typeof props.icon === 'string') return props.icon
-	return getDomainIcon(props.href)
-})
+const icon = computed(() => props.icon ?? getDomainIcon(props.href))
 const tip = computed(() => ({
 	content: isExtLink(props.href) ? getDomain(props.href) : safelyDecodeUriComponent(props.href),
 	inlinePositioning: true,

--- a/app/feeds.ts
+++ b/app/feeds.ts
@@ -72,7 +72,7 @@ export default [
 				avatar: getGithubAvatar('abloom25'),
 				archs: ['Nuxt', 'Cloudflare'],
 				date: '2024-12-09',
-				comment: '高中生，技术学习中。',
+				comment: '高中生，技术学习中，因AI发展太快差点学会前端。',
 			},
 			{
 				author: 'Mugzx',


### PR DESCRIPTION
这个拉取请求对 `ProseA.vue` 组件进行了一项小更新，改进了 `icon` 值的确定方式。改动将计算 `icon` 时的逻辑或运算符（`||`）换成了空值合并运算符（`??`），从而避免空字符串或 `false` 等假值意外触发后备逻辑。

*   更新了 `ProseA.vue` 中的 `icon` 计算属性，使用空值合并运算符（`??`）替代逻辑或运算符（`||`），以更精确地处理 `icon` 的值。