### PR TITLE
fix: 修复 ICO 预渲染与模板初始化，更新字体和 CDN 资源

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@
 
 ### 安装依赖
 
+需要 Node.js 22.19+（22.x）、24.11+（24.x）或 26+，推荐使用满足要求的最新 LTS 版本。
+
 ```sh
 pnpm i
 ```
@@ -137,12 +139,17 @@ pnpm i
 ### 初始配置
 
 ```sh
-pnpm init-project # 初始化项目配置
+pnpm init-project # 初始化项目配置，输入 confirm 确认
 ```
 
-- 在启动或部署项目时，你需要移除我的文章、我的个人信息、我的统计/评论配置。
+初始化会删除整个 `content` 目录，重建示例文章与通用友链申请说明，重置 `app/feeds.ts`（仅保留主题作者纸鹿的博客），并清空个人导航及统计/评论配置。请先备份自己的内容；自动化环境可显式执行 `pnpm init-project --yes`，没有确认参数时会退出且不修改文件。
+
+初始化后头像和图标使用 WeAvatar 首字占位头像（无需邮箱或 MD5），站点地址为 `http://localhost:3000/`。上线前请按终端清单修改：
+
+- 站点与个人配置：
   - `blog.config.ts` 中的站点信息、Umami 站点统计、Cloudflare Insights 统计、Twikoo 评论服务源。
-  - `app.config.ts` 中的页脚导航、出生年份等。
+  - `app/app.config.ts` 中的页脚导航、出生年份等（`birthYear: 0` 隐藏年龄）。
+  - `content/link.md` 中的友链申请方式、`app/feeds.ts` 中的友链列表。
 
 - 为保证开发体验，需要安装 ESLint、Stylelint 等 VS Code 扩展。如果你不喜欢此项目的格式化风格，可以在 `./eslint.config.mjs` 和 `./.vscode/settings.json` 中调整或者不安装 VS Code 扩展。
 
@@ -180,6 +187,9 @@ pnpm preview
 如果直接使用平台提供的“Nuxt”预设部署，则会变成 SSR 模式，此模式每次访问都会等待服务端重新渲染。请参阅 [Nuxt 文档](https://nuxt.com/docs/getting-started/deployment) 和 [Nuxt Content 文档](https://content.nuxt.com/docs/deploy/static) 的“部署”一节。
 
 #### 疑难解答
+
+- 手动清理文章后若 `generate` 报 `Exiting due to prerender errors`，请在完整日志中搜索 `[404]` 和 `Linked from`，修正引用已删除文章的链接。推荐在全新模板上使用初始化命令统一清理。
+- `absolute-site-urls` 表示站内链接使用了绝对 URL，并非 IP 地址无效。Atom / OPML 等订阅信息需要绝对地址；自托管时将 `blog.config.ts` 的 `url` 设为实际访问地址，且协议、主机、端口保持一致。
 
 - 当你发现文章页面 404 问题时，请注意文章 URL 不应尾随 `/`。
 - 如果修改了 API 路径，使用 EdgeOne Makers 部署需要同步修改 `edgeone.json`。

--- a/app/assets/css/font.scss
+++ b/app/assets/css/font.scss
@@ -3,6 +3,11 @@
 		open-digits: 1;
 		disambiguation: 2;
 		round-quotes-and-commas: 3;
+		disambiguation-except-zero: 4;
+		circled-characters: 5;
+		squared-characters: 6;
+		square-punctuation: 7;
+		square-quotes: 8;
 	}
 }
 
@@ -11,6 +16,11 @@
 		open-digits: 1;
 		disambiguation: 2;
 		round-quotes-and-commas: 3;
+		disambiguation-except-zero: 4;
+		circled-characters: 5;
+		squared-characters: 6;
+		square-punctuation: 7;
+		square-quotes: 8;
 	}
 }
 

--- a/app/assets/css/font.scss
+++ b/app/assets/css/font.scss
@@ -1,12 +1,12 @@
 :root {
-	--font-basic: "InterVariable", /* Android/Linux */ "sans-serif", /* Firefox */ "Noto Sans SC", sans-serif;
+	--font-basic: "Inter", /* Android/Linux */ "sans-serif", /* Firefox */ "Noto Sans SC", sans-serif;
 	--font-serif: /* Windows */ "Noto Serif SC-Local", "Noto Serif SC", serif;
-	--font-creative: "DOUYINSANSBOLD-GB", "InterVariable", sans-serif;
+	--font-creative: "DOUYINSANSBOLD-GB", "Inter", sans-serif;
 	--font-stroke-free: "DOUYINSANSBOLD-GB", "Inter", /* macOS */ "Lantinghei SC", /* Windows */ "Microsoft YaHei", sans-serif;
 	--font-monospace: "JetBrains Mono", /* Android/Linux */ "monospace", /* Windows */ "Cascadia Code", /* Windows */ "Consolas", /* Apple */ "Monaco", var(--font-basic), monospace;
 
 	@media (max-resolution: 1.2dppx) {
-		--font-basic: "InterVariable", system-ui, sans-serif;
+		--font-basic: "Inter", system-ui, sans-serif;
 	}
 }
 

--- a/app/assets/css/font.scss
+++ b/app/assets/css/font.scss
@@ -10,26 +10,22 @@
 	}
 }
 
-@mixin inter-styleset($font-family) {
-	@font-feature-values "#{$font-family}" {
-		@styleset {
-			open-digits: 1;
-			disambiguation: 2;
-			round-quotes-and-commas: 3;
-			disambiguation-except-zero: 4;
-			circled-characters: 5;
-			squared-characters: 6;
-			square-punctuation: 7;
-			square-quotes: 8;
-		}
+@font-feature-values "InterVariable", "Inter" {
+	@styleset {
+		open-digits: 1;
+		disambiguation: 2;
+		round-quotes-and-commas: 3;
+		disambiguation-except-zero: 4;
+		circled-characters: 5;
+		squared-characters: 6;
+		square-punctuation: 7;
+		square-quotes: 8;
 	}
 }
 
-@include inter-styleset(InterVariable);
-@include inter-styleset(Inter);
+/* 仅在 Chrome 130+ 启用本地可变字体 */
 
 /* autoprefixer: ignore next */
-// 仅在 Chrome 130+ 启用本地可变字体
 @supports (box-decoration-break: clone) {
 	@font-face {
 		font-family: "Noto Serif SC-Local";

--- a/app/assets/css/font.scss
+++ b/app/assets/css/font.scss
@@ -1,12 +1,12 @@
 :root {
-	--font-basic: "Inter", /* Android/Linux */ "sans-serif", /* Firefox */ "Noto Sans SC", sans-serif;
+	--font-basic: "InterVariable", /* Android/Linux */ "sans-serif", /* Firefox */ "Noto Sans SC", sans-serif;
 	--font-serif: /* Windows */ "Noto Serif SC-Local", "Noto Serif SC", serif;
-	--font-creative: "DOUYINSANSBOLD-GB", "Inter", sans-serif;
+	--font-creative: "DOUYINSANSBOLD-GB", "InterVariable", sans-serif;
 	--font-stroke-free: "DOUYINSANSBOLD-GB", "Inter", /* macOS */ "Lantinghei SC", /* Windows */ "Microsoft YaHei", sans-serif;
 	--font-monospace: "JetBrains Mono", /* Android/Linux */ "monospace", /* Windows */ "Cascadia Code", /* Windows */ "Consolas", /* Apple */ "Monaco", var(--font-basic), monospace;
 
 	@media (max-resolution: 1.2dppx) {
-		--font-basic: "Inter", system-ui, sans-serif;
+		--font-basic: "InterVariable", system-ui, sans-serif;
 	}
 }
 

--- a/app/assets/css/font.scss
+++ b/app/assets/css/font.scss
@@ -1,3 +1,19 @@
+@font-feature-values InterVariable {
+	@styleset {
+		open-digits: 1;
+		disambiguation: 2;
+		round-quotes-and-commas: 3;
+	}
+}
+
+@font-feature-values Inter {
+	@styleset {
+		open-digits: 1;
+		disambiguation: 2;
+		round-quotes-and-commas: 3;
+	}
+}
+
 :root {
 	--font-basic: "InterVariable", /* Android/Linux */ "sans-serif", /* Firefox */ "Noto Sans SC", sans-serif;
 	--font-serif: /* Windows */ "Noto Serif SC-Local", "Noto Serif SC", serif;

--- a/app/assets/css/font.scss
+++ b/app/assets/css/font.scss
@@ -1,29 +1,3 @@
-@font-feature-values InterVariable {
-	@styleset {
-		open-digits: 1;
-		disambiguation: 2;
-		round-quotes-and-commas: 3;
-		disambiguation-except-zero: 4;
-		circled-characters: 5;
-		squared-characters: 6;
-		square-punctuation: 7;
-		square-quotes: 8;
-	}
-}
-
-@font-feature-values Inter {
-	@styleset {
-		open-digits: 1;
-		disambiguation: 2;
-		round-quotes-and-commas: 3;
-		disambiguation-except-zero: 4;
-		circled-characters: 5;
-		squared-characters: 6;
-		square-punctuation: 7;
-		square-quotes: 8;
-	}
-}
-
 :root {
 	--font-basic: "InterVariable", /* Android/Linux */ "sans-serif", /* Firefox */ "Noto Sans SC", sans-serif;
 	--font-serif: /* Windows */ "Noto Serif SC-Local", "Noto Serif SC", serif;
@@ -35,6 +9,24 @@
 		--font-basic: "InterVariable", system-ui, sans-serif;
 	}
 }
+
+@mixin inter-styleset($font-family) {
+	@font-feature-values "#{$font-family}" {
+		@styleset {
+			open-digits: 1;
+			disambiguation: 2;
+			round-quotes-and-commas: 3;
+			disambiguation-except-zero: 4;
+			circled-characters: 5;
+			squared-characters: 6;
+			square-punctuation: 7;
+			square-quotes: 8;
+		}
+	}
+}
+
+@include inter-styleset(InterVariable);
+@include inter-styleset(Inter);
 
 /* autoprefixer: ignore next */
 // 仅在 Chrome 130+ 启用本地可变字体

--- a/app/components/content/FeedCard.vue
+++ b/app/components/content/FeedCard.vue
@@ -13,6 +13,11 @@ const title = computed(() => props.title ?? props.sitenick ?? props.author)
 const domainTip = computed(() => getDomainType(getMainDomain(props.link, true)))
 const domainIcon = computed(() => getDomainIcon(props.link))
 
+/** IPX 使用 Sharp，无法处理 ICO 格式 */
+function getImageProvider(src: string) {
+	return /\.ico(?:[?#]|$)/i.test(src) ? 'none' : undefined
+}
+
 function getInspectStyle(src: string): CSSProperties {
 	src = getMainDomain(src)
 	let color = 'red'
@@ -44,11 +49,11 @@ function getInspectStyle(src: string): CSSProperties {
 		<div class="avatar" :title="feed ? undefined : '无订阅源'">
 			<ClientOnly v-if="isInspect">
 				<span style="position: absolute; left: 100%; white-space: nowrap;" v-text="title" />
-				<NuxtImg :src="icon" :title="icon" :style="getInspectStyle(icon)" />
-				<NuxtImg :src="avatar" :title="avatar" :style="getInspectStyle(avatar)" />
+				<NuxtImg :src="icon" :provider="getImageProvider(icon)" :title="icon" :style="getInspectStyle(icon)" />
+				<NuxtImg :src="avatar" :provider="getImageProvider(avatar)" :title="avatar" :style="getInspectStyle(avatar)" />
 			</ClientOnly>
 
-			<NuxtImg v-else class="round-cobblestone" :src="avatar" :alt="author" loading="lazy" />
+			<NuxtImg v-else class="round-cobblestone" :src="avatar" :provider="getImageProvider(avatar)" :alt="author" loading="lazy" />
 			<Icon v-if="appConfig.link.remindNoFeed && !feed" class="no-feed" name="tabler:bell-off" />
 		</div>
 
@@ -58,7 +63,7 @@ function getInspectStyle(src: string): CSSProperties {
 
 	<template #content>
 		<div class="site-content">
-			<NuxtImg class="site-icon" :src="icon" :alt="title" />
+			<NuxtImg class="site-icon" :src="icon" :provider="getImageProvider(icon)" :alt="title" />
 
 			<div class="site-info">
 				<h3 class="text-creative">

--- a/app/components/content/FeedCard.vue
+++ b/app/components/content/FeedCard.vue
@@ -2,6 +2,7 @@
 import type { CSSProperties } from 'vue'
 import type { FeedEntry } from '~/types/feed'
 import { Temporal } from 'temporal-polyfill'
+import { parseURL } from 'ufo'
 
 const props = defineProps<FeedEntry>()
 
@@ -15,7 +16,8 @@ const domainIcon = computed(() => getDomainIcon(props.link))
 
 /** IPX 使用 Sharp，无法处理 ICO 格式 */
 function getImageProvider(src: string) {
-	return /\.ico(?:[?#]|$)/i.test(src) ? 'none' : undefined
+	const isIco = parseURL(src).pathname.toLowerCase().endsWith('.ico')
+	return isIco ? 'none' : undefined
 }
 
 function getInspectStyle(src: string): CSSProperties {
@@ -24,7 +26,7 @@ function getInspectStyle(src: string): CSSProperties {
 
 	if (src === getMainDomain(props.link))
 		color = 'transparent' // 来自源站
-	else if (src === 'gstatic.cn')
+	else if (src === 'gstatic.cn' || src === 'webp.se')
 		color = 'yellow' // 来自API获取
 	else if (src === 'qlogo.cn')
 		color = 'lightblue' // 来自QQ头像

--- a/app/components/content/FeedCard.vue
+++ b/app/components/content/FeedCard.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import type { CSSProperties } from 'vue'
 import type { FeedEntry } from '~/types/feed'
+// eslint-disable-next-line unused-imports/no-unused-imports
 import { Temporal } from 'temporal-polyfill'
-import { parseURL } from 'ufo'
 
 const props = defineProps<FeedEntry>()
 
@@ -13,12 +13,6 @@ const isInspect = computed(() => import.meta.dev && route.query.inspect !== unde
 const title = computed(() => props.title ?? props.sitenick ?? props.author)
 const domainTip = computed(() => getDomainType(getMainDomain(props.link, true)))
 const domainIcon = computed(() => getDomainIcon(props.link))
-
-/** IPX 使用 Sharp，无法处理 ICO 格式 */
-function getImageProvider(src: string) {
-	const isIco = parseURL(src).pathname.toLowerCase().endsWith('.ico')
-	return isIco ? 'none' : undefined
-}
 
 function getInspectStyle(src: string): CSSProperties {
 	src = getMainDomain(src)
@@ -51,11 +45,11 @@ function getInspectStyle(src: string): CSSProperties {
 		<div class="avatar" :title="feed ? undefined : '无订阅源'">
 			<ClientOnly v-if="isInspect">
 				<span style="position: absolute; left: 100%; white-space: nowrap;" v-text="title" />
-				<NuxtImg :src="icon" :provider="getImageProvider(icon)" :title="icon" :style="getInspectStyle(icon)" />
-				<NuxtImg :src="avatar" :provider="getImageProvider(avatar)" :title="avatar" :style="getInspectStyle(avatar)" />
+				<NuxtImg :src="icon" :title="icon" :style="getInspectStyle(icon)" />
+				<NuxtImg :src="avatar" :title="avatar" :style="getInspectStyle(avatar)" />
 			</ClientOnly>
 
-			<NuxtImg v-else class="round-cobblestone" :src="avatar" :provider="getImageProvider(avatar)" :alt="author" loading="lazy" />
+			<NuxtImg v-else class="round-cobblestone" :src="avatar" :alt="author" loading="lazy" />
 			<Icon v-if="appConfig.link.remindNoFeed && !feed" class="no-feed" name="tabler:bell-off" />
 		</div>
 
@@ -65,7 +59,7 @@ function getInspectStyle(src: string): CSSProperties {
 
 	<template #content>
 		<div class="site-content">
-			<NuxtImg class="site-icon" :src="icon" :provider="getImageProvider(icon)" :alt="title" />
+			<NuxtImg class="site-icon" :src="icon" :alt="title" loading="lazy" />
 
 			<div class="site-info">
 				<h3 class="text-creative">

--- a/app/components/content/FeedCard.vue
+++ b/app/components/content/FeedCard.vue
@@ -24,7 +24,7 @@ function getInspectStyle(src: string): CSSProperties {
 
 	if (src === getMainDomain(props.link))
 		color = 'transparent' // 来自源站
-	else if (src === 'webp.se')
+	else if (src === 'gstatic.cn')
 		color = 'yellow' // 来自API获取
 	else if (src === 'qlogo.cn')
 		color = 'lightblue' // 来自QQ头像

--- a/app/feeds.ts
+++ b/app/feeds.ts
@@ -1695,7 +1695,7 @@ export default [
 				desc: '分享技术与生活趣事',
 				link: 'https://blog.aevi.top/',
 				feed: 'https://blog.aevi.top/feed.xml',
-				icon: getFavicon('blog.aevi.top'),
+				icon: getFavicon('blog.aevi.top', { provider: 'duckduckgo' }),
 				avatar: getGithubAvatar('tongzanyang'),
 				archs: ['Halo', '服务器'],
 				date: '2026-02-05',

--- a/app/feeds.ts
+++ b/app/feeds.ts
@@ -1695,7 +1695,7 @@ export default [
 				desc: '分享技术与生活趣事',
 				link: 'https://blog.aevi.top/',
 				feed: 'https://blog.aevi.top/feed.xml',
-				icon: getFavicon('blog.aevi.top', { provider: 'duckduckgo' }),
+				icon: getFavicon('blog.aevi.top'),
 				avatar: getGithubAvatar('tongzanyang'),
 				archs: ['Halo', '服务器'],
 				date: '2026-02-05',

--- a/app/pages/archive.vue
+++ b/app/pages/archive.vue
@@ -80,7 +80,7 @@ function getArticleYear(article: ArticleProps) {
 				{{ year }}
 			</h2>
 
-			<div class="archive-age">
+			<div v-if="birthYear" class="archive-age">
 				<span>{{ Number(year) - birthYear }}</span>
 				<span class="age-label">岁</span>
 			</div>

--- a/app/utils/img.ts
+++ b/app/utils/img.ts
@@ -54,15 +54,12 @@ export function getOciqGroupAvatar(group = '', size = QgroupAvatarSize.Size100) 
 }
 
 interface FaviconOptions {
-	provider?: 'google' | 'duckduckgo' | 'microlink'
 	size?: number
 }
 
-// https://github.com/microlinkhq/unavatar
-// https://docs.webp.se/public-services/unavatar/
 export function getFavicon(domain: string, options?: FaviconOptions) {
-	const { provider = 'google', size = 32 } = options || {}
-	return `https://unavatar.webp.se/${provider}/${domain}?w=${size}`
+	const { size = 32 } = options || {}
+	return `https://t0.gstatic.cn/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://${domain}&size=${size}`
 }
 
 export function getImgUrl(src: string, service?: ImgService | true) {

--- a/app/utils/img.ts
+++ b/app/utils/img.ts
@@ -53,15 +53,22 @@ export function getOciqGroupAvatar(group = '', size = QgroupAvatarSize.Size100) 
 	return `https://p.qlogo.cn/gh/${group}/${group}/${size}/`
 }
 
-interface FaviconOptions {
-	provider?: 'google' | 'duckduckgo' | 'microlink'
+interface GstaticFaviconOptions {
+	provider?: 'gstatic'
+	size?: 16 | 32 | 64 | 96 | 128 | 256 | 512
+}
+
+interface WebpseFaviconOptions {
+	provider: 'google' | 'duckduckgo' | 'microlink'
 	size?: number
 }
 
-export function getFavicon(domain: string, options?: FaviconOptions) {
-	const { provider = 'google', size = 32 } = options || {}
-	if (provider === 'google')
-		return `https://t0.gstatic.cn/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://${domain}&size=${size}`
+// https://github.com/microlinkhq/unavatar
+// https://docs.webp.se/public-services/unavatar/
+export function getFavicon(domain: string, options?: GstaticFaviconOptions | WebpseFaviconOptions) {
+	const { provider = 'gstatic', size = 32 } = options || {}
+	if (provider === 'gstatic')
+		return `https://t0.gstatic.cn/faviconV2?client=SOCIAL&fallback_opts=SIZE&url=http://${domain}&size=${size}`
 	return `https://unavatar.webp.se/${provider}/${domain}?w=${size}`
 }
 

--- a/app/utils/img.ts
+++ b/app/utils/img.ts
@@ -54,12 +54,15 @@ export function getOciqGroupAvatar(group = '', size = QgroupAvatarSize.Size100) 
 }
 
 interface FaviconOptions {
+	provider?: 'google' | 'duckduckgo' | 'microlink'
 	size?: number
 }
 
 export function getFavicon(domain: string, options?: FaviconOptions) {
-	const { size = 32 } = options || {}
-	return `https://t0.gstatic.cn/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://${domain}&size=${size}`
+	const { provider = 'google', size = 32 } = options || {}
+	if (provider === 'google')
+		return `https://t0.gstatic.cn/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=http://${domain}&size=${size}`
+	return `https://unavatar.webp.se/${provider}/${domain}?w=${size}`
 }
 
 export function getImgUrl(src: string, service?: ImgService | true) {

--- a/blog.config.ts
+++ b/blog.config.ts
@@ -78,7 +78,7 @@ const blogConfig = {
 		// 自己网站的 Cloudflare Insights 统计服务
 		{ 'src': 'https://static.cloudflareinsights.com/beacon.min.js', 'data-cf-beacon': '{"token": "97a4fe32ed8240ac8284e9bffaf03962"}', 'defer': true },
 		// Twikoo 评论系统
-		{ src: 'https://registry.npmmirror.com/twikoo/1.7.13/files/dist/twikoo.min.js', defer: true },
+		{ src: 'https://registry.npmmirror.com/twikoo/latest/files/dist/twikoo.min.js', defer: true },
 	],
 
 	/** 自己部署的 Twikoo 服务 */

--- a/blog.config.ts
+++ b/blog.config.ts
@@ -78,7 +78,7 @@ const blogConfig = {
 		// 自己网站的 Cloudflare Insights 统计服务
 		{ 'src': 'https://static.cloudflareinsights.com/beacon.min.js', 'data-cf-beacon': '{"token": "97a4fe32ed8240ac8284e9bffaf03962"}', 'defer': true },
 		// Twikoo 评论系统
-		{ src: 'https://s4.zstatic.net/ajax/libs/twikoo/1.7.13/twikoo.min.js', defer: true },
+		{ src: 'https://registry.npmmirror.com/twikoo/1.7.13/files/dist/twikoo.min.js', defer: true },
 	],
 
 	/** 自己部署的 Twikoo 服务 */

--- a/blog.config.ts
+++ b/blog.config.ts
@@ -78,7 +78,7 @@ const blogConfig = {
 		// 自己网站的 Cloudflare Insights 统计服务
 		{ 'src': 'https://static.cloudflareinsights.com/beacon.min.js', 'data-cf-beacon': '{"token": "97a4fe32ed8240ac8284e9bffaf03962"}', 'defer': true },
 		// Twikoo 评论系统
-		{ src: 'https://registry.npmmirror.com/twikoo/latest/files/dist/twikoo.min.js', defer: true },
+		{ src: 'https://s4.zstatic.net/npm/twikoo@1.7.20/dist/twikoo.min.js', defer: true },
 	],
 
 	/** 自己部署的 Twikoo 服务 */

--- a/blog.config.ts
+++ b/blog.config.ts
@@ -78,7 +78,7 @@ const blogConfig = {
 		// 自己网站的 Cloudflare Insights 统计服务
 		{ 'src': 'https://static.cloudflareinsights.com/beacon.min.js', 'data-cf-beacon': '{"token": "97a4fe32ed8240ac8284e9bffaf03962"}', 'defer': true },
 		// Twikoo 评论系统
-		{ src: 'https://cdnjs.snrat.com/ajax/libs/twikoo/1.7.13/twikoo.min.js', defer: true },
+		{ src: 'https://s4.zstatic.net/ajax/libs/twikoo/1.7.13/twikoo.min.js', defer: true },
 	],
 
 	/** 自己部署的 Twikoo 服务 */

--- a/content/theme.md
+++ b/content/theme.md
@@ -72,7 +72,7 @@ class: gradient-card active
 ---
 banner: https://assets.zhilu.cyou/cover3/blog-using-nuxt.jpg
 title: 博客进化：从 Hexo 到 Nuxt Content
-link: /2024/blog-using-nuxt
+link: https://blog.zhilu.site/2024/blog-using-nuxt
 ---
 ::
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
 				{ rel: 'icon', href: blogConfig.favicon },
 				{ rel: 'alternate', type: 'application/atom+xml', href: '/atom.xml' },
 				{ rel: 'preconnect', href: blogConfig.twikoo.preload },
-				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/ajax/libs/KaTeX/0.16.44/katex.min.css' },
+				{ rel: 'stylesheet', href: 'https://registry.npmmirror.com/katex/0.16.44/files/dist/katex.min.css' },
 				// "InterVariable", "Inter"
 				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter-variable.css' },
 				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter.css' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,8 +29,9 @@ export default defineNuxtConfig({
 				{ rel: 'alternate', type: 'application/atom+xml', href: '/atom.xml' },
 				{ rel: 'preconnect', href: blogConfig.twikoo.preload },
 				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/ajax/libs/KaTeX/0.16.44/katex.min.css' },
-				// "InterVariable", "Inter", "InterDisplay"
-				{ rel: 'stylesheet', href: 'https://oss1.236668.xyz/fonts/inter/inter.css?_upd=inter.css&_upt=ce56c2851787252944' },
+				// "InterVariable", "Inter"
+				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter-variable.css' },
+				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter.css' },
 				// "JetBrains Mono", 思源宋体 "Noto Serif SC"
 				{ rel: 'preconnect', href: 'https://fonts.gstatic.cn', crossorigin: '' },
 				{ rel: 'stylesheet', href: 'https://fonts.googleapis.cn/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Noto+Serif+SC:wght@200..900&display=swap' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,7 +28,7 @@ export default defineNuxtConfig({
 				{ rel: 'icon', href: blogConfig.favicon },
 				{ rel: 'alternate', type: 'application/atom+xml', href: '/atom.xml' },
 				{ rel: 'preconnect', href: blogConfig.twikoo.preload },
-				{ rel: 'stylesheet', href: 'https://registry.npmmirror.com/katex/0.16.44/files/dist/katex.min.css' },
+				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/katex@0.16.44/dist/katex.min.css' },
 				// "InterVariable", "Inter"
 				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter-variable.css' },
 				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/npm/inter-ui@4.1.1/inter.css' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,8 +29,8 @@ export default defineNuxtConfig({
 				{ rel: 'alternate', type: 'application/atom+xml', href: '/atom.xml' },
 				{ rel: 'preconnect', href: blogConfig.twikoo.preload },
 				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/ajax/libs/KaTeX/0.16.44/katex.min.css' },
-				// "Inter"
-				{ rel: 'stylesheet', href: 'https://fonts.googleapis.cn/css2?family=Inter:wght@400;500;600;700&display=swap' },
+				// "InterVariable", "Inter", "InterDisplay"
+				{ rel: 'stylesheet', href: 'https://oss1.236668.xyz/fonts/inter/inter.css?_upd=inter.css&_upt=ce56c2851787252944' },
 				// "JetBrains Mono", 思源宋体 "Noto Serif SC"
 				{ rel: 'preconnect', href: 'https://fonts.gstatic.cn', crossorigin: '' },
 				{ rel: 'stylesheet', href: 'https://fonts.googleapis.cn/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Noto+Serif+SC:wght@200..900&display=swap' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,9 +28,9 @@ export default defineNuxtConfig({
 				{ rel: 'icon', href: blogConfig.favicon },
 				{ rel: 'alternate', type: 'application/atom+xml', href: '/atom.xml' },
 				{ rel: 'preconnect', href: blogConfig.twikoo.preload },
-				{ rel: 'stylesheet', href: 'https://cdnjs.snrat.com/ajax/libs/KaTeX/0.16.44/katex.min.css' },
-				// "InterVariable", "Inter", "InterDisplay"
-				{ rel: 'stylesheet', href: 'https://rsms.me/inter/inter.css' },
+				{ rel: 'stylesheet', href: 'https://s4.zstatic.net/ajax/libs/KaTeX/0.16.44/katex.min.css' },
+				// "Inter"
+				{ rel: 'stylesheet', href: 'https://fonts.googleapis.cn/css2?family=Inter:wght@400;500;600;700&display=swap' },
 				// "JetBrains Mono", 思源宋体 "Noto Serif SC"
 				{ rel: 'preconnect', href: 'https://fonts.gstatic.cn', crossorigin: '' },
 				{ rel: 'stylesheet', href: 'https://fonts.googleapis.cn/css2?family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&family=Noto+Serif+SC:wght@200..900&display=swap' },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "(MIT OR CC-BY-NC-SA-4.0)",
   "homepage": "https://github.com/L33Z22L11/blog-v3",
   "engines": {
-    "node": "^22.18 || ^23.6 || >=24",
+    "node": "^22.19 || ^24.11 || >=26",
     "pnpm": ">=10"
   },
   "scripts": {

--- a/patches/ipx.patch
+++ b/patches/ipx.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/_chunks/node-fs.mjs b/dist/_chunks/node-fs.mjs
+index fecfc99f8bfa4dc145c053373342f2ae1529514d..db8fad0908978a8c8f02e401179e28fe649d4fe7 100644
+--- a/dist/_chunks/node-fs.mjs
++++ b/dist/_chunks/node-fs.mjs
+@@ -969,6 +969,13 @@ function createIPX(userOptions) {
+ 						meta: imageMeta$1
+ 					};
+ 				}
++				if (imageMeta$1.type === "ico" && (!mFormat || mFormat === "ico")) {
++					return {
++						data: sourceData,
++						format: "x-icon",
++						meta: imageMeta$1
++					};
++				}
+ 				const format = mFormat && SUPPORTED_FORMATS.has(mFormat) ? mFormat : SUPPORTED_FORMATS.has(imageMeta$1.type || "") ? imageMeta$1.type : "jpeg";
+ 				const animated = modifiers.animated !== void 0 || modifiers.a !== void 0 || format === "gif";
+ 				const Sharp = await getSharp();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,7 @@ catalogs:
 patchedDependencies:
   '@nuxt/image': 579706651997597c070d331e56e6cf9f3deb05477e3696c678c5c49ff614ea9c
   '@nuxtjs/mdc': e0283e75f475e855851a8b791250710895e1946f9f5e93eef1d27db151c44a64
+  ipx: 2e5548ae5d736ba30cec5dac96383122d63b6056b4b116d4138668889c9a9360
   plain-shiki: 56851d6c1b4dd6fc387d2cd7e584f71d4da7066ca6177e1df1cdae8903dd72be
 
 importers:
@@ -217,7 +218,7 @@ importers:
         version: 4.0.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       '@nuxtjs/seo':
         specifier: catalog:content
-        version: 5.3.12(3138fe5f979f2fb4f6e53abef90aca2d)
+        version: 5.3.12(0c011b0a9a68ec9e594415aab1c6f264)
       '@pinia/nuxt':
         specifier: catalog:util
         version: 1.0.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
@@ -232,7 +233,7 @@ importers:
         version: 14.4.0(vue@3.5.41(typescript@6.0.3))
       '@vueuse/nuxt':
         specifier: catalog:util
-        version: 14.4.0(31ca5c1e7df23d32eae4a74f3a8c1d4d)
+        version: 14.4.0(78dd31673c8526c181f59968fd5efc60)
       '@vueuse/router':
         specifier: catalog:util
         version: 14.4.0(vue-router@5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3)))(vue@3.5.41(typescript@6.0.3))
@@ -259,7 +260,7 @@ importers:
         version: 7.2.0
       nuxt:
         specifier: catalog:framework
-        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+        version: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
       parse-domain:
         specifier: catalog:util
         version: 8.3.2
@@ -317,7 +318,7 @@ importers:
         version: 1.0.0-alpha.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/hints':
         specifier: catalog:quality
-        version: 1.1.4(@parcel/watcher@2.6.0)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
+        version: 1.1.4(@parcel/watcher@2.6.0)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.4)(srvx@0.12.5)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@zinkawaii/stylelint-config':
         specifier: catalog:quality
         version: 0.5.2(postcss-html@1.8.1)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))
@@ -1421,6 +1422,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/sourcemap-codec@1.6.0':
+    resolution: {integrity: sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==}
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
@@ -5399,6 +5403,9 @@ packages:
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
+  ohash@2.0.12:
+    resolution: {integrity: sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==}
+
   on-change@6.0.2:
     resolution: {integrity: sha512-08+12qcOVEA0fS9g/VxKS27HaT94nRutUT77J2dr8zv/unzXopvhBuF8tNLWsoLQ5IgrQ6eptGeGqUYat82U1w==}
     engines: {node: '>=20'}
@@ -5422,6 +5429,10 @@ packages:
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
+  open@11.0.1:
+    resolution: {integrity: sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==}
     engines: {node: '>=20'}
 
   optionator@0.9.4:
@@ -5807,6 +5818,10 @@ packages:
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  powershell-utils@0.2.0:
+    resolution: {integrity: sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==}
     engines: {node: '>=20'}
 
   prelude-ls@1.2.1:
@@ -7175,6 +7190,10 @@ packages:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
 
+  wsl-utils@1.0.0:
+    resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
+    engines: {node: '>=20'}
+
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
@@ -8251,7 +8270,7 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
@@ -8267,6 +8286,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/sourcemap-codec@1.6.0': {}
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
@@ -8574,7 +8595,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/hints@1.1.4(@parcel/watcher@2.6.0)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.4)(srvx@0.11.22)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
+  '@nuxt/hints@1.1.4(@parcel/watcher@2.6.0)(db0@0.3.4)(esbuild@0.28.2)(ioredis@5.11.1(supports-color@10.2.2))(magicast@0.5.4)(rolldown@1.2.3)(rollup@4.62.4)(srvx@0.12.5)(supports-color@10.2.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/kit': 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(oxc-parser@0.140.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
@@ -8585,7 +8606,7 @@ snapshots:
       html-validate: 11.6.2
       knitwork: 1.3.0
       magic-string: 0.30.21
-      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
+      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       oxc-parser: 0.140.0
       prettier: 3.9.6
       sirv: 3.0.2
@@ -8685,7 +8706,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
     optionalDependencies:
-      ipx: 4.0.0-beta.1(@types/node@26.2.0)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2)))
+      ipx: 4.0.0-beta.1(patch_hash=2e5548ae5d736ba30cec5dac96383122d63b6056b4b116d4138668889c9a9360)(@types/node@26.2.0)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2)))
     transitivePeerDependencies:
       - '@types/node'
       - magic-string
@@ -8708,7 +8729,7 @@ snapshots:
       klona: 2.0.6
       mlly: 1.8.2
       nostics: 1.2.0
-      ohash: 2.0.11
+      ohash: 2.0.12
       pathe: 2.0.3
       pkg-types: 2.3.1
       rc9: 3.0.1
@@ -8738,7 +8759,7 @@ snapshots:
       klona: 2.0.6
       mlly: 1.8.2
       nostics: 1.2.0
-      ohash: 2.0.11
+      ohash: 2.0.12
       pathe: 2.0.3
       pkg-types: 2.3.1
       rc9: 3.0.1
@@ -8768,7 +8789,7 @@ snapshots:
       klona: 2.0.6
       mlly: 1.8.2
       nostics: 1.2.0
-      ohash: 2.0.11
+      ohash: 2.0.12
       pathe: 2.0.3
       pkg-types: 2.3.1
       rc9: 3.0.1
@@ -8785,7 +8806,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.2(2b54e8b12a00c87eef134d3a471bfb20)':
+  '@nuxt/nitro-server@4.5.2(e6dd85cf60bb065f4c905225939f5026)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
@@ -8802,9 +8823,9 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
+      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       nostics: 1.2.0
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
@@ -8889,7 +8910,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.2(c9657c291dfd113246c80c7c47938e0b)':
+  '@nuxt/vite-builder@4.5.2(bc8812d29ed6752d2b82004d68fd171e)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
@@ -8907,7 +8928,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -9026,15 +9047,15 @@ snapshots:
       - supports-color
       - unplugin
 
-  '@nuxtjs/robots@6.1.4(1cc368e758df0a276060e2cab998c3cb)':
+  '@nuxtjs/robots@6.1.4(abddf6f9e5a81269e439fccf3f74f071)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -9051,18 +9072,18 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.3.12(3138fe5f979f2fb4f6e53abef90aca2d)':
+  '@nuxtjs/seo@5.3.12(0c011b0a9a68ec9e594415aab1c6f264)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
-      '@nuxtjs/robots': 6.1.4(1cc368e758df0a276060e2cab998c3cb)
-      '@nuxtjs/sitemap': 8.3.4(1cc368e758df0a276060e2cab998c3cb)
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
-      nuxt-link-checker: 5.1.3(6f059adc068a2f4eb6c08f843fb32d03)
-      nuxt-og-image: 6.7.7(643c4545b3b2c93a98256fc4366e7ba0)
-      nuxt-schema-org: 6.2.9(bb6501872c077e66e79cb3f21490968a)
-      nuxt-seo-utils: 8.3.3(41b95fca0ddf2af55cb940ab1fcd8ce6)
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      '@nuxtjs/robots': 6.1.4(abddf6f9e5a81269e439fccf3f74f071)
+      '@nuxtjs/sitemap': 8.3.4(abddf6f9e5a81269e439fccf3f74f071)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt-link-checker: 5.1.3(cb51a060ea71b32ee8de38acbb0d02b5)
+      nuxt-og-image: 6.7.7(60874ae140a7c1e18522091ec1c46eb6)
+      nuxt-schema-org: 6.2.9(1e6ebaadff5ea38d7a391f1280a2b134)
+      nuxt-seo-utils: 8.3.3(c8a800fadd3a6f4923d663f1c933002c)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -9121,13 +9142,13 @@ snapshots:
       - webpack
       - zod
 
-  '@nuxtjs/sitemap@8.3.4(1cc368e758df0a276060e2cab998c3cb)':
+  '@nuxtjs/sitemap@8.3.4(abddf6f9e5a81269e439fccf3f74f071)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       consola: 3.4.2
       defu: 6.1.7
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -10144,13 +10165,13 @@ snapshots:
 
   '@vueuse/metadata@14.4.0': {}
 
-  '@vueuse/nuxt@14.4.0(31ca5c1e7df23d32eae4a74f3a8c1d4d)':
+  '@vueuse/nuxt@14.4.0(78dd31673c8526c181f59968fd5efc60)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
       '@vueuse/metadata': 14.4.0
       local-pkg: 1.2.1
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
       vue: 3.5.41(typescript@6.0.3)
     transitivePeerDependencies:
       - magic-string
@@ -10590,6 +10611,10 @@ snapshots:
   crossws@0.4.10(srvx@0.11.22):
     optionalDependencies:
       srvx: 0.11.22
+
+  crossws@0.4.10(srvx@0.12.5):
+    optionalDependencies:
+      srvx: 0.12.5
 
   cspell-config-lib@10.0.1:
     dependencies:
@@ -11865,7 +11890,7 @@ snapshots:
 
   ip-regex@5.0.0: {}
 
-  ipx@4.0.0-beta.1(@types/node@26.2.0)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))):
+  ipx@4.0.0-beta.1(patch_hash=2e5548ae5d736ba30cec5dac96383122d63b6056b4b116d4138668889c9a9360)(@types/node@26.2.0)(unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))):
     dependencies:
       sharp: 0.35.3(@types/node@26.2.0)
       srvx: 0.12.5
@@ -12165,6 +12190,29 @@ snapshots:
     transitivePeerDependencies:
       - srvx
 
+  listhen@1.10.1(@parcel/watcher@2.6.0)(srvx@0.12.5):
+    dependencies:
+      '@parcel/watcher-wasm': 2.6.0
+      citty: 0.2.2
+      consola: 3.4.2
+      crossws: 0.4.10(srvx@0.12.5)
+      defu: 6.1.7
+      get-port-please: 3.2.0
+      h3: 1.15.11
+      http-shutdown: 1.2.2
+      jiti: 2.7.0
+      node-forge: 1.4.0
+      pathe: 2.0.3
+      std-env: 4.2.0
+      tinyclip: 0.1.15
+      ufo: 1.6.4
+      untun: 0.2.2
+      uqr: 0.1.3
+    optionalDependencies:
+      '@parcel/watcher': 2.6.0
+    transitivePeerDependencies:
+      - srvx
+
   loader-utils@3.3.1: {}
 
   local-pkg@1.2.1:
@@ -12201,7 +12249,7 @@ snapshots:
 
   magic-string@1.1.0:
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/sourcemap-codec': 1.6.0
 
   magicast@0.5.4:
     dependencies:
@@ -12650,7 +12698,7 @@ snapshots:
 
   natural-orderby@5.0.0: {}
 
-  nitropack@2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)):
+  nitropack@2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.140.0)(rolldown@1.2.3)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -12688,7 +12736,7 @@ snapshots:
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
-      listhen: 1.10.1(@parcel/watcher@2.6.0)(srvx@0.11.22)
+      listhen: 1.10.1(@parcel/watcher@2.6.0)(srvx@0.12.5)
       magic-string: 0.30.21
       magicast: 0.5.4
       mime: 4.1.0
@@ -12696,7 +12744,7 @@ snapshots:
       node-fetch-native: 1.6.7
       node-mock-http: 1.0.5
       ofetch: 1.5.1
-      ohash: 2.0.11
+      ohash: 2.0.12
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
@@ -12762,7 +12810,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)):
+  nitropack@2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -12800,7 +12848,7 @@ snapshots:
       jiti: 2.7.0
       klona: 2.0.6
       knitwork: 1.3.0
-      listhen: 1.10.1(@parcel/watcher@2.6.0)(srvx@0.11.22)
+      listhen: 1.10.1(@parcel/watcher@2.6.0)(srvx@0.12.5)
       magic-string: 0.30.21
       magicast: 0.5.4
       mime: 4.1.0
@@ -12808,7 +12856,7 @@ snapshots:
       node-fetch-native: 1.6.7
       node-mock-http: 1.0.5
       ofetch: 1.5.1
-      ohash: 2.0.11
+      ohash: 2.0.12
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
@@ -12941,7 +12989,7 @@ snapshots:
       - magicast
       - rolldown
 
-  nuxt-link-checker@5.1.3(6f059adc068a2f4eb6c08f843fb32d03):
+  nuxt-link-checker@5.1.3(cb51a060ea71b32ee8de38acbb0d02b5):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       '@vueuse/core': 14.4.0(vue@3.5.41(typescript@6.0.3))
@@ -12950,9 +12998,9 @@ snapshots:
       fuse.js: 7.5.0
       h3: 1.15.11
       magic-string: 1.1.0
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -13000,7 +13048,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  nuxt-og-image@6.7.7(643c4545b3b2c93a98256fc4366e7ba0):
+  nuxt-og-image@6.7.7(60874ae140a7c1e18522091ec1c46eb6):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
@@ -13016,8 +13064,8 @@ snapshots:
       magic-string: 1.1.0
       magicast: 0.5.4
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
       nypm: 0.6.9
       object-identity: 0.2.3
       ofetch: 1.5.1
@@ -13035,7 +13083,7 @@ snapshots:
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))
     optionalDependencies:
-      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(srvx@0.11.22)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
+      nitropack: 2.13.4(@parcel/watcher@2.6.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       zod: 4.4.3
     transitivePeerDependencies:
       - '@farmfe/core'
@@ -13053,12 +13101,12 @@ snapshots:
       - vue
       - webpack
 
-  nuxt-schema-org@6.2.9(bb6501872c077e66e79cb3f21490968a):
+  nuxt-schema-org@6.2.9(1e6ebaadff5ea38d7a391f1280a2b134):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       defu: 6.1.7
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
       pkg-types: 2.3.1
       ufo: 1.6.4
     optionalDependencies:
@@ -13076,7 +13124,7 @@ snapshots:
       - vite
       - vue
 
-  nuxt-seo-utils@8.3.3(41b95fca0ddf2af55cb940ab1fcd8ce6):
+  nuxt-seo-utils@8.3.3(c8a800fadd3a6f4923d663f1c933002c):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
       citty: 0.2.2
@@ -13085,9 +13133,9 @@ snapshots:
       escape-string-regexp: 5.0.0
       exsolve: 1.1.1
       image-size: 2.0.2
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
       pathe: 2.0.3
       pkg-types: 2.3.1
       scule: 1.3.0
@@ -13126,7 +13174,7 @@ snapshots:
       - unplugin
       - vue
 
-  nuxt-site-config@4.2.1(1cc368e758df0a276060e2cab998c3cb):
+  nuxt-site-config@4.2.1(abddf6f9e5a81269e439fccf3f74f071):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
@@ -13134,7 +13182,7 @@ snapshots:
       defu: 6.1.7
       h3: 1.15.11
       nuxt-site-config-kit: 4.2.1(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vue@3.5.41(typescript@6.0.3))
-      nuxtseo-shared: 5.3.12(246047b82c50f0dc296f9e4e5e10153d)
+      nuxtseo-shared: 5.3.12(876c627795f015204763e516e1dde049)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.2.1(vue@3.5.41(typescript@6.0.3))
@@ -13151,16 +13199,16 @@ snapshots:
       - vite
       - zod
 
-  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0):
+  nuxt@4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.2)(@parcel/watcher@2.6.0)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
       '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2))(magic-string@1.1.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(supports-color@10.2.2)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@nuxt/kit': 4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))
-      '@nuxt/nitro-server': 4.5.2(2b54e8b12a00c87eef134d3a471bfb20)
+      '@nuxt/nitro-server': 4.5.2(e6dd85cf60bb065f4c905225939f5026)
       '@nuxt/schema': 4.5.2
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.2(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))))
-      '@nuxt/vite-builder': 4.5.2(c9657c291dfd113246c80c7c47938e0b)
+      '@nuxt/vite-builder': 4.5.2(bc8812d29ed6752d2b82004d68fd171e)
       '@unhead/vue': 3.3.1(@oxc-project/types@0.143.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.143.0)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(vue@3.5.41(typescript@6.0.3))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -13293,7 +13341,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-shared@5.3.12(246047b82c50f0dc296f9e4e5e10153d):
+  nuxtseo-shared@5.3.12(876c627795f015204763e516e1dde049):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.3)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.3)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))
@@ -13302,7 +13350,7 @@ snapshots:
       birpc: 4.1.0
       consola: 3.4.2
       defu: 6.1.7
-      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.11.22)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
+      nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@oxc-project/types@0.143.0)(@parcel/watcher@2.6.0)(@types/node@26.2.0)(@vue/compiler-sfc@3.5.41)(commander@14.0.3)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0)(supports-color@10.2.2))(ioredis@5.11.1(supports-color@10.2.2))(lightningcss@1.33.0)(magicast@0.5.4)(meow@14.1.0)(optionator@0.9.4)(oxc-parser@0.143.0)(pinia@4.0.2(@vue/devtools-api@8.2.1)(typescript@6.0.3)(vue@3.5.41(typescript@6.0.3)))(rolldown@1.2.3)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4))(rollup@4.62.4)(sass-embedded@1.100.0)(sass@1.100.0)(srvx@0.12.5)(stylelint@17.14.1(supports-color@10.2.2)(typescript@6.0.3))(supports-color@10.2.2)(terser@5.49.2)(typescript@6.0.3)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.49.2)(yaml@2.9.0))(yaml@2.9.0)
       nypm: 0.6.9
       ofetch: 1.5.1
       pathe: 2.0.3
@@ -13313,7 +13361,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.41(typescript@6.0.3)
     optionalDependencies:
-      nuxt-site-config: 4.2.1(1cc368e758df0a276060e2cab998c3cb)
+      nuxt-site-config: 4.2.1(abddf6f9e5a81269e439fccf3f74f071)
       zod: 4.4.3
     transitivePeerDependencies:
       - magic-string
@@ -13345,6 +13393,8 @@ snapshots:
 
   ohash@2.0.11: {}
 
+  ohash@2.0.12: {}
+
   on-change@6.0.2: {}
 
   on-finished@2.4.1:
@@ -13375,6 +13425,15 @@ snapshots:
       is-inside-container: 1.0.0
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
+
+  open@11.0.1:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.2.0
+      wsl-utils: 1.0.0
 
   optionator@0.9.4:
     dependencies:
@@ -13820,6 +13879,8 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  powershell-utils@0.2.0: {}
+
   prelude-ls@1.2.1: {}
 
   prettier@3.9.6: {}
@@ -14113,7 +14174,7 @@ snapshots:
 
   rollup-plugin-visualizer@7.0.1(rolldown@1.2.3)(rollup@4.62.4):
     dependencies:
-      open: 11.0.0
+      open: 11.0.1
       picomatch: 4.0.5
       source-map: 0.7.6
       yargs: 18.1.0
@@ -15341,6 +15402,11 @@ snapshots:
   ws@8.21.3: {}
 
   wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
+  wsl-utils@1.0.0:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,8 @@ patchedDependencies:
   # 代码块不将 tab 转为空格
   # 行内代码 props.code 传入原文
   '@nuxtjs/mdc': patches/@nuxtjs__mdc.patch
+  # IPX 的 Sharp 无法处理 ICO ，但改变运行时 NuxtImg provider 有类型问题 https://github.com/nuxt/image/issues/2174
+  ipx: patches/ipx.patch
   # adoptedStyleSheet ::highlight 高亮选择器
   plain-shiki: patches/plain-shiki.patch
 

--- a/scripts/init-project.ts
+++ b/scripts/init-project.ts
@@ -7,54 +7,106 @@ import { Temporal } from 'temporal-polyfill'
 
 intro('初始化博客：删除原有文章、配置')
 
-const confirm = await text({
-	message: '此操作会导致所有文章、配置文件丢失！输入“confirm”确认',
-})
-
-if (confirm !== 'confirm') {
-	log.error('已取消')
+const args = process.argv.slice(2).filter(arg => arg !== '--')
+if (args.some(arg => arg !== '--yes')) {
+	log.error('未知参数。用法：pnpm init-project [--yes]')
 	process.exit(1)
 }
+if (!args.includes('--yes')) {
+	if (!process.stdin.isTTY) {
+		log.error('非交互环境请使用 pnpm init-project --yes；此操作会删除所有文章并重置配置，请先备份。')
+		process.exit(1)
+	}
+	const confirm = await text({
+		message: '此操作会导致所有文章、配置文件丢失！输入“confirm”确认',
+	})
+	if (confirm !== 'confirm') {
+		log.error('已取消')
+		process.exit(1)
+	}
+}
+
+const placeholderAvatar = 'https://weavatar.com/avatar/?d=initials&name=博主'
+const today = Temporal.Now.plainDateISO()
+const postDir = `./content/posts/${today.year}`
+const examplePath = './content/previews/example.md'
+if (!fs.existsSync(examplePath)) {
+	log.error('示例文章不存在，请在未初始化的模板副本中运行；未修改任何文件。')
+	process.exit(1)
+}
+
+// 在删除文章前读取并准备全部配置，避免源文件缺失时只完成一半初始化。
+const exampleContent = fs.readFileSync(examplePath, 'utf8')
+const appConfigContent = fs.readFileSync('./app/app.config.ts', 'utf8')
+	.replace(/logo: '[^']*'/, 'logo: blogConfig.author.avatar')
+	.replaceAll('\'/theme\'', '\'https://blog.zhilu.site/theme\'')
+	.replace(/^.*\{ icon:.*(?:jq\.qq\.com|travellings\.cn|github\.com\/(?:L33Z22L11|octocat)'|beian\.miit\.gov\.cn).*\n/gm, '')
+	.replace(/birthYear: \d+/, 'birthYear: 0')
+	.replace(/wordCount: '[^']*'/, 'wordCount: \'\'')
+	.replace(/emojiTail: \[[^\]]*\]/, 'emojiTail: [\'📝\', \'✨\', \'🌱\']')
+
+const blogConfigContent = fs.readFileSync('./blog.config.ts', 'utf8')
+	.replace(/title: '[^']*'/, 'title: \'我的博客\'')
+	.replace(/subtitle: '[^']*'/, 'subtitle: \'记录技术与生活\'')
+	.replace(/description: '[^']*'/, 'description: \'分享学习笔记、技术实践与日常生活。\'')
+	.replace(/name: '[^']*'/, 'name: \'博主\'')
+	.replace(/avatar: '[^']*'/, `avatar: '${placeholderAvatar}'`)
+	.replace(/email: '[^']*'/, 'email: \'\'')
+	.replace(/homepage: '[^']*'/, 'homepage: \'/\'')
+	.replace(/favicon: '[^']*'/, `favicon: '${placeholderAvatar}'`)
+	.replace(/timeEstablished: '[^']*'/, `timeEstablished: '${today}'`)
+	.replace(/\n\turl: '[^']*'/, '\n\turl: \'http://localhost:3000/\'')
+	.replace(/\n\tscripts: \[[\s\S]*?\n\t\],/, '\n\tscripts: [],')
+	.replace(/envId: '[^']*'/, 'envId: \'\'')
+	.replace(/preload: '[^']*'/, 'preload: \'\'')
+	.replace(/sitenick: '[^']*'/, 'sitenick: blogConfig.title')
+	.replace(/archs: \[[^\]]*\]/, 'archs: [\'Nuxt\']')
 
 const s = spinner()
 s.start('正在处理文章、配置文件...')
-
-// 清空 content 目录并新建示例文章
-const PATH_LINK_MD = './content/link.md'
-const PATH_EXAMPLE_MD = './content/previews/example.md'
-const PATH_NEW_MD = `./content/posts/${Temporal.Now.plainDateISO().year.toString()}`
-const linkMdContent = fs.readFileSync(PATH_LINK_MD, 'utf8')
-if (!fs.existsSync(PATH_EXAMPLE_MD)) {
-	s.stop('示例文章不存在')
-	process.exit(1)
-}
-const exampleMdContent = fs.readFileSync(PATH_EXAMPLE_MD, 'utf8')
 fs.rmSync('./content', { recursive: true, force: true })
-fs.mkdirSync(PATH_NEW_MD, { recursive: true })
-fs.writeFileSync(PATH_LINK_MD, linkMdContent)
-fs.writeFileSync(`${PATH_NEW_MD}/example.md`, exampleMdContent)
+fs.mkdirSync(postDir, { recursive: true })
+fs.writeFileSync(`${postDir}/example.md`, exampleContent)
+fs.writeFileSync('./content/link.md', `---
+date: ${today}
+---
 
-// 处理 app.config.ts
-const PATH_APP_CONFIG = './app/app.config.ts'
-const appConfigContent = fs.readFileSync(PATH_APP_CONFIG, 'utf8')
-	.replace(/'.*?avatar.com.*?'/, 'blogConfig.author.avatar')
-	.replaceAll('L33Z22L11\'', 'octocat\'')
-	.replace('\'/theme\'', `'https://blog.zhilu.site/theme'`)
-	.replace(/'.?ICP备.*?'/, '\'备案\'')
-fs.writeFileSync(PATH_APP_CONFIG, appConfigContent)
+<!-- 请在上线前填写自己的联系方式或启用评论区。 -->
 
-// 处理 blog.config.ts
-const PATH_BLOG_CONFIG = './blog.config.ts'
-const blogConfigContent = fs.readFileSync(PATH_BLOG_CONFIG, 'utf8')
-	.replace(/'[^']*纸鹿[^']*'/g, '\'博客\'')
-	.replace(/'[^']*zhilu[^']*'/g, match => match.replace('zhilu', 'example'))
-fs.writeFileSync(PATH_BLOG_CONFIG, blogConfigContent)
+- 欢迎交换友链：持续维护，分享原创内容。
+- 请提供博客名称、地址、简介和头像。
+- 申请方式：待博主补充。
+`)
+fs.writeFileSync('./app/feeds.ts', `import type { FeedGroup } from './types/feed'
 
-// 处理 redirects.json
-fs.writeFileSync('./redirects.json', `{
-  "/theme": "https://blog.zhilu.site/theme"
-}`)
-
+export default [{
+	name: '清晰体验',
+	desc: '使用 Clarity 博客主题构建的网站。',
+	entries: [{
+		author: '纸鹿本鹿',
+		sitenick: '摸鱼处',
+		title: '纸鹿摸鱼处',
+		desc: '纸鹿至麓不知路，支炉制露不止漉',
+		link: 'https://blog.zhilu.site/',
+		feed: 'https://blog.zhilu.site/atom.xml',
+		icon: 'https://www.zhilu.site/api/icon.png',
+		avatar: 'https://www.zhilu.site/api/avatar.png',
+		archs: ['Nuxt', 'Vercel'],
+		date: '2019-07-19',
+		comment: 'Clarity 主题作者',
+	}],
+}] satisfies FeedGroup[]
+`)
+fs.writeFileSync('./app/app.config.ts', appConfigContent)
+fs.writeFileSync('./blog.config.ts', blogConfigContent)
+fs.writeFileSync('./redirects.json', `${JSON.stringify({ '/theme': 'https://blog.zhilu.site/theme' }, null, 2)}\n`)
 s.stop('初始化完成')
 
+log.info(`上线前请修改以下配置：
+- blog.config.ts：title / subtitle / description、author（当前名称：博主，邮箱为空，主页为 /）
+- blog.config.ts：url（当前 http://localhost:3000/），请改为实际访问地址
+- blog.config.ts：author.avatar / favicon（当前 ${placeholderAvatar}），请换成自己的图片
+- blog.config.ts：timeEstablished（当前 ${today}）、scripts / twikoo（当前未启用）
+- app/app.config.ts：footer 导航、header.emojiTail、component.stats（birthYear 为 0，年龄已隐藏）
+- content/link.md：申请方式；app/feeds.ts：友链列表（当前仅保留纸鹿摸鱼处）`)
 outro('请参照 README.md 完成后续配置')


### PR DESCRIPTION
友链使用 ICO 图片时，IPX 会交给 Sharp 处理并导致预渲染失败；模板初始化还会留下原作者配置，影响新站部署。本次修复图片处理与初始化流程，并更新外部资源地址。

- IPX 根据图片内容识别 ICO，在未要求转码或显式指定 ICO 时原样返回；保留其他格式处理逻辑。友链弹层图标启用懒加载。
- 默认 favicon 服务改为 Gstatic Favicon V2，保留原有 webp.se provider 选项。
- KaTeX、Twikoo、Inter 资源改用 ZStatic，Twikoo 更新至 1.7.20；保留 InterVariable / Inter，并使用原生 CSS 声明字形样式集。
- Node 最低版本与 Nuxt 依赖对齐；初始化支持 `--yes`，未确认的非交互运行在修改前退出。
- 初始化重置友链（仅保留纸鹿摸鱼处），清理个人导航、统计与评论配置，生成通用申请说明；使用无需邮箱或 MD5 的 WeAvatar 首字占位头像，设置当天建站日期并提示上线前配置项。未设置出生年份时隐藏年龄。
- 修正主题页对原作者文章的站内引用，补充静态部署、预渲染 404 和绝对站内链接告警说明。

验证：相关 ESLint、Stylelint、初始化保护与配置产物测试通过；初始化产物曾完成静态生成（25 个路由、0 个链接错误、1 个 absolute-site-urls 警告）。独立 IPX 副本应用补丁后，ICO 原始字节及 SVG 直通检查通过。最新提交 `d375149` 的 Netlify Deploy Preview 已成功；两项 Vercel 检查因 fork 部署需要授权而未运行成功。

ICO 补丁不提供转码或缩放；显式请求将 ICO 转为 WebP / JPEG 等格式仍不受 Sharp 支持。未在反馈者的 ECS 环境重测。